### PR TITLE
Refactor CommandProcessor for asynchronous execution

### DIFF
--- a/sample/BIGprocess_mock_cartridge.hpp
+++ b/sample/BIGprocess_mock_cartridge.hpp
@@ -13,33 +13,31 @@ public:
     // 1. 入力用の構造体を定義
     struct Input
     {
-        unsigned int input_mesh_id;
+        unsigned int time_to_process;
     };
 
     // 2. 出力用の構造体を定義 (複数の値を返す例)
     struct Output
     {
-        unsigned int generated_point_cloud_id;
+        unsigned int time_slept;
         std::string message;
     };
-    std::string command_name="BIGprocess_mock";
-    std::string description = "Mock cartridge of long process";
+    static inline const std::string command_name="BIGprocess_mock";
+    static inline const std::string description = "Mock cartridge of long process";
     // 3. 処理本体を実装
     Output
     execute(const Input &input) const
     {
-        std::cout << "\n--- Executing BIGprocess_mock_cartridge (by sleep) ---" << std::endl;
-        std::cout << "  Processing Mesh ID: " << input.input_mesh_id << std::endl;
+        std::cout << "\n--- Executing BIGprocess_mock_cartridge (will sleep for " << input.time_to_process << " seconds) ---" << std::endl;
 
-        // 3秒間スリープ
-        std::cout << "sleep 1 sec..." << std::endl;
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-        std::cout << "sleep finished" << std::endl;
+        std::this_thread::sleep_for(std::chrono::seconds(input.time_to_process));
+
+        std::cout << "--- BIGprocess_mock_cartridge finished sleeping ---" << std::endl;
 
         // Output構造体に結果を詰めて返す
         return Output{
-            .generated_point_cloud_id = input.input_mesh_id + 1000,
-            .message = "Successfully sleeped"};
+            .time_slept = input.time_to_process,
+            .message = "Successfully slept"};
     }
 };
 


### PR DESCRIPTION
Refactored the CommandProcessor to execute commands on a separate worker thread, making it non-blocking.

- Introduced `start()` and `stop()` methods to manage the worker thread's lifecycle.
- Used `std::thread`, `std::mutex`, and `std::condition_variable` to ensure thread-safe operation.
- Modified the main sample application to demonstrate the asynchronous behavior with a long-running mock cartridge.
- This change allows the main thread to remain responsive while commands are being processed in the background.