### PR TITLE
feat: Implement 3D rendering of STL files with selectable shaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ target_link_libraries(CommandProcessor PUBLIC spdlog::spdlog reflectcpp::reflect
 target_include_directories(CommandProcessor PUBLIC include)
 
 # Create a library for the client code
-add_library(ClientLib source/BaseClient.cpp source/ConsoleClient.cpp source/GuiClient.cpp)
+add_library(ClientLib source/BaseClient.cpp source/ConsoleClient.cpp source/GuiClient.cpp source/Shader.cpp source/Camera.cpp source/RenderableMesh.cpp)
 target_include_directories(ClientLib PUBLIC include sample)
 target_link_libraries(ClientLib PUBLIC
     spdlog::spdlog

--- a/include/MITSUDomoe/Camera.hpp
+++ b/include/MITSUDomoe/Camera.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+namespace MITSU_Domoe {
+
+enum Camera_Movement {
+    FORWARD,
+    BACKWARD,
+    LEFT,
+    RIGHT
+};
+
+const float YAW         = -90.0f;
+const float PITCH       =  0.0f;
+const float SPEED       =  2.5f;
+const float SENSITIVITY =  0.1f;
+const float ZOOM        =  45.0f;
+
+class Camera {
+public:
+    Eigen::Vector3f Position;
+    Eigen::Vector3f Front;
+    Eigen::Vector3f Up;
+    Eigen::Vector3f Right;
+    Eigen::Vector3f WorldUp;
+
+    float Yaw;
+    float Pitch;
+
+    float MovementSpeed;
+    float MouseSensitivity;
+    float Zoom;
+
+    Camera(Eigen::Vector3f position = Eigen::Vector3f(0.0f, 0.0f, 0.0f), Eigen::Vector3f up = Eigen::Vector3f(0.0f, 1.0f, 0.0f), float yaw = YAW, float pitch = PITCH);
+
+    Eigen::Matrix4f GetViewMatrix();
+    Eigen::Matrix4d GetViewMatrixDouble();
+
+    void ProcessKeyboard(Camera_Movement direction, float deltaTime);
+    void ProcessMouseMovement(float xoffset, float yoffset, bool constrainPitch = true);
+    void ProcessMouseScroll(float yoffset);
+
+private:
+    void updateCameraVectors();
+};
+
+}

--- a/include/MITSUDomoe/GuiClient.hpp
+++ b/include/MITSUDomoe/GuiClient.hpp
@@ -1,6 +1,15 @@
 #pragma once
 
 #include "BaseClient.hpp"
+#include "Shader.hpp"
+#include "Camera.hpp"
+#include "RenderableMesh.hpp"
+
+#include <map>
+#include <string>
+#include <memory>
+
+struct GLFWwindow;
 
 namespace MITSU_Domoe
 {
@@ -9,9 +18,28 @@ class GuiClient : public BaseClient
 {
 public:
     GuiClient();
-    ~GuiClient() = default;
+    ~GuiClient();
 
     void run() override;
+
+private:
+    void process_input(GLFWwindow* window);
+    void ProcessMouseMovement(double xpos, double ypos);
+    void ProcessMouseScroll(double yoffset);
+
+
+    Camera camera;
+    float lastX = 1280.0f / 2.0f;
+    float lastY = 720.0f / 2.0f;
+    bool firstMouse = true;
+
+    float deltaTime = 0.0f;
+    float lastFrame = 0.0f;
+
+    std::map<std::string, std::unique_ptr<Shader>> shaders;
+    std::string current_shader_name;
+
+    std::map<uint64_t, std::unique_ptr<RenderableMesh>> renderable_meshes;
 };
 
 }

--- a/include/MITSUDomoe/RenderableMesh.hpp
+++ b/include/MITSUDomoe/RenderableMesh.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "MITSUDomoe/3D_objects.hpp"
+#include "MITSUDomoe/Shader.hpp"
+#include <glad/glad.h>
+
+namespace MITSU_Domoe {
+
+class RenderableMesh {
+public:
+    RenderableMesh(const Polygon_mesh& mesh);
+    ~RenderableMesh();
+
+    void draw(Shader& shader);
+
+private:
+    GLuint VAO, VBO, EBO;
+    GLsizei index_count;
+};
+
+}

--- a/include/MITSUDomoe/Shader.hpp
+++ b/include/MITSUDomoe/Shader.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <glad/glad.h>
+#include <Eigen/Dense>
+
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+namespace MITSU_Domoe {
+
+class Shader {
+public:
+    unsigned int ID;
+
+    Shader(const char* vertexPath, const char* fragmentPath, const char* geometryPath = nullptr);
+    ~Shader();
+
+    void use();
+
+    void setBool(const std::string &name, bool value) const;
+    void setInt(const std::string &name, int value) const;
+    void setFloat(const std::string &name, float value) const;
+    void setVec2(const std::string &name, const Eigen::Vector2f &value) const;
+    void setVec3(const std::string &name, const Eigen::Vector3f &value) const;
+    void setVec4(const std::string &name, const Eigen::Vector4f &value) const;
+    void setMat2(const std::string &name, const Eigen::Matrix2f &mat) const;
+    void setMat3(const std::string &name, const Eigen::Matrix3f &mat) const;
+    void setMat4(const std::string &name, const Eigen::Matrix4f &mat) const;
+    void setDMat4(const std::string &name, const Eigen::Matrix4d &mat) const;
+
+private:
+    void checkCompileErrors(GLuint shader, std::string type);
+};
+
+}

--- a/shader/normal_color.frag
+++ b/shader/normal_color.frag
@@ -1,0 +1,9 @@
+#version 450 core
+out vec4 FragColor;
+
+in vec3 FragNormal;
+
+void main()
+{
+    FragColor = vec4(FragNormal * 0.5 + 0.5, 1.0);
+}

--- a/shader/normal_color.geom
+++ b/shader/normal_color.geom
@@ -1,0 +1,32 @@
+#version 450 core
+layout (triangles) in;
+layout (triangle_strip, max_vertices = 3) out;
+
+uniform dmat4 mvp;
+
+out vec3 FragNormal;
+
+void main()
+{
+    vec3 v0 = gl_in[0].gl_Position.xyz;
+    vec3 v1 = gl_in[1].gl_Position.xyz;
+    vec3 v2 = gl_in[2].gl_Position.xyz;
+
+    vec3 faceNormal = normalize(cross(v1 - v0, v2 - v0));
+
+    mat4 mvp_float = mat4(mvp);
+
+    gl_Position = mvp_float * gl_in[0].gl_Position;
+    FragNormal = faceNormal;
+    EmitVertex();
+
+    gl_Position = mvp_float * gl_in[1].gl_Position;
+    FragNormal = faceNormal;
+    EmitVertex();
+
+    gl_Position = mvp_float * gl_in[2].gl_Position;
+    FragNormal = faceNormal;
+    EmitVertex();
+
+    EndPrimitive();
+}

--- a/shader/normal_color.vert
+++ b/shader/normal_color.vert
@@ -1,0 +1,7 @@
+#version 450 core
+layout (location = 0) in vec3 aPos;
+
+void main()
+{
+    gl_Position = vec4(aPos, 1.0);
+}

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -1,0 +1,101 @@
+#include "MITSUDomoe/Camera.hpp"
+#include <Eigen/Geometry>
+
+namespace MITSU_Domoe {
+
+namespace {
+    Eigen::Matrix4f lookAt(const Eigen::Vector3f& position, const Eigen::Vector3f& target, const Eigen::Vector3f& up) {
+        Eigen::Vector3f f = (target - position).normalized();
+        Eigen::Vector3f s = f.cross(up).normalized();
+        Eigen::Vector3f u = s.cross(f);
+
+        Eigen::Matrix4f mat = Eigen::Matrix4f::Identity();
+        mat(0, 0) = s.x(); mat(0, 1) = s.y(); mat(0, 2) = s.z(); mat(0, 3) = -s.dot(position);
+        mat(1, 0) = u.x(); mat(1, 1) = u.y(); mat(1, 2) = u.z(); mat(1, 3) = -u.dot(position);
+        mat(2, 0) = -f.x(); mat(2, 1) = -f.y(); mat(2, 2) = -f.z(); mat(2, 3) = f.dot(position);
+        return mat;
+    }
+
+    Eigen::Matrix4d lookAt(const Eigen::Vector3d& position, const Eigen::Vector3d& target, const Eigen::Vector3d& up) {
+        Eigen::Vector3d f = (target - position).normalized();
+        Eigen::Vector3d s = f.cross(up).normalized();
+        Eigen::Vector3d u = s.cross(f);
+
+        Eigen::Matrix4d mat = Eigen::Matrix4d::Identity();
+        mat(0, 0) = s.x(); mat(0, 1) = s.y(); mat(0, 2) = s.z(); mat(0, 3) = -s.dot(position);
+        mat(1, 0) = u.x(); mat(1, 1) = u.y(); mat(1, 2) = u.z(); mat(1, 3) = -u.dot(position);
+        mat(2, 0) = -f.x(); mat(2, 1) = -f.y(); mat(2, 2) = -f.z(); mat(2, 3) = f.dot(position);
+        return mat;
+    }
+}
+
+
+Camera::Camera(Eigen::Vector3f position, Eigen::Vector3f up, float yaw, float pitch) : Front(Eigen::Vector3f(0.0f, 0.0f, -1.0f)), MovementSpeed(SPEED), MouseSensitivity(SENSITIVITY), Zoom(ZOOM) {
+    Position = position;
+    WorldUp = up;
+    Yaw = yaw;
+    Pitch = pitch;
+    updateCameraVectors();
+}
+
+Eigen::Matrix4f Camera::GetViewMatrix() {
+    return lookAt(Position, Position + Front, Up);
+}
+
+Eigen::Matrix4d Camera::GetViewMatrixDouble() {
+    Eigen::Vector3d pos_d = Position.cast<double>();
+    Eigen::Vector3d front_d = Front.cast<double>();
+    Eigen::Vector3d up_d = Up.cast<double>();
+    return lookAt(pos_d, pos_d + front_d, up_d);
+}
+
+void Camera::ProcessKeyboard(Camera_Movement direction, float deltaTime) {
+    float velocity = MovementSpeed * deltaTime;
+    if (direction == FORWARD)
+        Position += Front * velocity;
+    if (direction == BACKWARD)
+        Position -= Front * velocity;
+    if (direction == LEFT)
+        Position -= Right * velocity;
+    if (direction == RIGHT)
+        Position += Right * velocity;
+}
+
+void Camera::ProcessMouseMovement(float xoffset, float yoffset, bool constrainPitch) {
+    xoffset *= MouseSensitivity;
+    yoffset *= MouseSensitivity;
+
+    Yaw += xoffset;
+    Pitch += yoffset;
+
+    if (constrainPitch) {
+        if (Pitch > 89.0f)
+            Pitch = 89.0f;
+        if (Pitch < -89.0f)
+            Pitch = -89.0f;
+    }
+
+    updateCameraVectors();
+}
+
+void Camera::ProcessMouseScroll(float yoffset) {
+    Zoom -= (float)yoffset;
+    if (Zoom < 1.0f)
+        Zoom = 1.0f;
+    if (Zoom > 45.0f)
+        Zoom = 45.0f;
+}
+
+void Camera::updateCameraVectors() {
+    Eigen::Vector3f front;
+    float yawRad = Yaw * M_PI / 180.0f;
+    float pitchRad = Pitch * M_PI / 180.0f;
+    front.x() = cos(yawRad) * cos(pitchRad);
+    front.y() = sin(pitchRad);
+    front.z() = sin(yawRad) * cos(pitchRad);
+    Front = front.normalized();
+    Right = Front.cross(WorldUp).normalized();
+    Up = Right.cross(Front).normalized();
+}
+
+}

--- a/source/GuiClient.cpp
+++ b/source/GuiClient.cpp
@@ -1,3 +1,5 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
 #include "MITSUDomoe/GuiClient.hpp"
 
 #include <imgui.h>
@@ -29,13 +31,72 @@ namespace
 namespace MITSU_Domoe
 {
 
-GuiClient::GuiClient()
+namespace {
+    Eigen::Matrix4f perspective(float fovY, float aspect, float zNear, float zFar) {
+        float tanHalfFovy = tan(fovY / 2.0f);
+        Eigen::Matrix4f res = Eigen::Matrix4f::Zero();
+        res(0, 0) = 1.0f / (aspect * tanHalfFovy);
+        res(1, 1) = 1.0f / (tanHalfFovy);
+        res(2, 2) = -(zFar + zNear) / (zFar - zNear);
+        res(3, 2) = -1.0f;
+        res(2, 3) = -(2.0f * zFar * zNear) / (zFar - zNear);
+        return res;
+    }
+}
+
+
+void GuiClient::ProcessMouseMovement(double xpos, double ypos) {
+    if (ImGui::IsMouseDown(0)) { // Only move camera if left mouse button is down
+        if (firstMouse) {
+            lastX = xpos;
+            lastY = ypos;
+            firstMouse = false;
+        }
+
+        float xoffset = xpos - lastX;
+        float yoffset = lastY - ypos;
+
+        lastX = xpos;
+        lastY = ypos;
+
+        camera.ProcessMouseMovement(xoffset, yoffset);
+    } else {
+        firstMouse = true;
+    }
+}
+
+void GuiClient::ProcessMouseScroll(double yoffset) {
+    camera.ProcessMouseScroll(yoffset);
+}
+
+
+GuiClient::GuiClient() : camera(Eigen::Vector3f(0.0f, 0.0f, 3.0f))
 {
     processor->register_cartridge(ReadStlCartridge{});
     processor->register_cartridge(GenerateCentroidsCartridge_mock{});
     processor->register_cartridge(GenerateCentroidsCartridge{});
     processor->register_cartridge(BIGprocess_mock_cartridge{});
     processor->register_cartridge(Need_many_arg_mock_cartridge{});
+
+    shaders["Edge Shader"] = std::make_unique<Shader>("shader/test_shader_with_mvp_edge_draw.vert", "shader/test_shader_with_mvp_edge_draw.frag", "shader/test_shader_with_mvp_edge_draw.geom");
+    shaders["Normal Color Shader"] = std::make_unique<Shader>("shader/normal_color.vert", "shader/normal_color.frag", "shader/normal_color.geom");
+    current_shader_name = "Edge Shader";
+}
+
+GuiClient::~GuiClient() {
+
+}
+
+void GuiClient::process_input(GLFWwindow *window)
+{
+    if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS)
+        camera.ProcessKeyboard(FORWARD, deltaTime);
+    if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS)
+        camera.ProcessKeyboard(BACKWARD, deltaTime);
+    if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS)
+        camera.ProcessKeyboard(LEFT, deltaTime);
+    if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS)
+        camera.ProcessKeyboard(RIGHT, deltaTime);
 }
 
 void GuiClient::run()
@@ -44,15 +105,43 @@ void GuiClient::run()
     if (!glfwInit())
         return;
 
-    const char* glsl_version = "#version 130";
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+    const char* glsl_version = "#version 450";
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
 
     GLFWwindow* window = glfwCreateWindow(1280, 720, "MITSUDomoe Client", nullptr, nullptr);
     if (window == nullptr) return;
     glfwMakeContextCurrent(window);
+    glfwSetWindowUserPointer(window, this);
+
     if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) return;
     glfwSwapInterval(1);
+
+    glEnable(GL_DEPTH_TEST);
+
+    unsigned int fbo;
+    glGenFramebuffers(1, &fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+
+    unsigned int textureColorbuffer;
+    glGenTextures(1, &textureColorbuffer);
+    glBindTexture(GL_TEXTURE_2D, textureColorbuffer);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 1280, 720, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorbuffer, 0);
+
+    unsigned int rbo;
+    glGenRenderbuffers(1, &rbo);
+    glBindRenderbuffer(GL_RENDERBUFFER, rbo);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, 1280, 720);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, rbo);
+
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        std::cout << "ERROR::FRAMEBUFFER:: Framebuffer is not complete!" << std::endl;
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
@@ -93,7 +182,33 @@ void GuiClient::run()
 
     while (!glfwWindowShouldClose(window))
     {
+        float currentFrame = glfwGetTime();
+        deltaTime = currentFrame - lastFrame;
+        lastFrame = currentFrame;
+
+        process_input(window);
+
         glfwPollEvents();
+
+        // Check for new results and create renderable meshes
+        auto results = get_all_results();
+        for (const auto& pair : results) {
+            uint64_t id = pair.first;
+            if (renderable_meshes.find(id) == renderable_meshes.end()) {
+                const auto& result = pair.second;
+                if (const auto* success = std::get_if<MITSU_Domoe::SuccessResult>(&result)) {
+                    if (success->command_name == "readStl") {
+                        // This is a bit of a hack, we should probably have a better way to get the mesh
+                        // For now, we deserialize it from the JSON output.
+                        rfl::Result<ReadStlCartridge::Output> output = rfl::json::read<ReadStlCartridge::Output>(success->output_json);
+                        if(output) {
+                            renderable_meshes[id] = std::make_unique<RenderableMesh>(output->polygon_mesh);
+                        }
+                    }
+                }
+            }
+        }
+
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
@@ -188,12 +303,67 @@ void GuiClient::run()
             ImGui::End();
         }
 
+        // 3D Scene Rendering
+        glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+        glEnable(GL_DEPTH_TEST);
+        glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        if (shaders.count(current_shader_name)) {
+            auto& shader = shaders.at(current_shader_name);
+            shader->use();
+
+            Eigen::Matrix4f proj = perspective(camera.Zoom * M_PI / 180.0f, 1280.0f / 720.0f, 0.1f, 100.0f);
+            Eigen::Matrix4d view = camera.GetViewMatrixDouble();
+            Eigen::Matrix4d model = Eigen::Matrix4d::Identity();
+            Eigen::Matrix4d mvp = proj.cast<double>() * view * model;
+
+            shader->setDMat4("mvp", mvp);
+
+            for (auto const& [id, mesh] : renderable_meshes) {
+                mesh->draw(*shader);
+            }
+        }
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+        // ImGui Rendering
         ImGui::Render();
         int display_w, display_h;
         glfwGetFramebufferSize(window, &display_w, &display_h);
         glViewport(0, 0, display_w, display_h);
         glClearColor(clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w, clear_color.w);
         glClear(GL_COLOR_BUFFER_BIT);
+
+        {
+            ImGui::Begin("3D Viewport");
+
+            if (ImGui::IsWindowHovered()) {
+                ImGuiIO& io = ImGui::GetIO();
+                ProcessMouseScroll(io.MouseWheel);
+                double xpos, ypos;
+                glfwGetCursorPos(window, &xpos, &ypos);
+                ProcessMouseMovement(xpos, ypos);
+            }
+
+            ImGui::BeginChild("ShaderSelector");
+            const char* current = current_shader_name.c_str();
+            if (ImGui::BeginCombo("Shader", current)) {
+                for (auto const& [name, shader] : shaders) {
+                    bool is_selected = (current_shader_name == name);
+                    if (ImGui::Selectable(name.c_str(), is_selected)) {
+                        current_shader_name = name;
+                    }
+                    if (is_selected) {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+                ImGui::EndCombo();
+            }
+            ImGui::EndChild();
+            ImGui::Image((ImTextureID)(intptr_t)textureColorbuffer, ImGui::GetContentRegionAvail(), ImVec2(0, 1), ImVec2(1, 0));
+            ImGui::End();
+        }
+
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
         glfwSwapBuffers(window);
     }

--- a/source/RenderableMesh.cpp
+++ b/source/RenderableMesh.cpp
@@ -1,0 +1,40 @@
+#include "MITSUDomoe/RenderableMesh.hpp"
+
+namespace MITSU_Domoe {
+
+RenderableMesh::RenderableMesh(const Polygon_mesh& mesh) {
+    glGenVertexArrays(1, &VAO);
+    glGenBuffers(1, &VBO);
+    glGenBuffers(1, &EBO);
+
+    glBindVertexArray(VAO);
+
+    glBindBuffer(GL_ARRAY_BUFFER, VBO);
+    glBufferData(GL_ARRAY_BUFFER, mesh.V.size() * sizeof(double), mesh.V.data(), GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh.F.size() * sizeof(int), mesh.F.data(), GL_STATIC_DRAW);
+
+    // Vertex positions
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_DOUBLE, GL_FALSE, 3 * sizeof(double), (void*)0);
+
+    glBindVertexArray(0);
+
+    index_count = mesh.F.size();
+}
+
+RenderableMesh::~RenderableMesh() {
+    glDeleteVertexArrays(1, &VAO);
+    glDeleteBuffers(1, &VBO);
+    glDeleteBuffers(1, &EBO);
+}
+
+void RenderableMesh::draw(Shader& shader) {
+    shader.use();
+    glBindVertexArray(VAO);
+    glDrawElements(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, 0);
+    glBindVertexArray(0);
+}
+
+}

--- a/source/Shader.cpp
+++ b/source/Shader.cpp
@@ -1,0 +1,145 @@
+#include "MITSUDomoe/Shader.hpp"
+
+namespace MITSU_Domoe {
+
+Shader::Shader(const char* vertexPath, const char* fragmentPath, const char* geometryPath) {
+    std::string vertexCode;
+    std::string fragmentCode;
+    std::string geometryCode;
+    std::ifstream vShaderFile;
+    std::ifstream fShaderFile;
+    std::ifstream gShaderFile;
+
+    vShaderFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    fShaderFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    gShaderFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+    try {
+        vShaderFile.open(vertexPath);
+        fShaderFile.open(fragmentPath);
+        std::stringstream vShaderStream, fShaderStream;
+        vShaderStream << vShaderFile.rdbuf();
+        fShaderStream << fShaderFile.rdbuf();
+        vShaderFile.close();
+        fShaderFile.close();
+        vertexCode = vShaderStream.str();
+        fragmentCode = fShaderStream.str();
+
+        if (geometryPath != nullptr) {
+            gShaderFile.open(geometryPath);
+            std::stringstream gShaderStream;
+            gShaderStream << gShaderFile.rdbuf();
+            gShaderFile.close();
+            geometryCode = gShaderStream.str();
+        }
+    } catch (std::ifstream::failure& e) {
+        std::cout << "ERROR::SHADER::FILE_NOT_SUCCESSFULLY_READ: " << e.what() << std::endl;
+    }
+
+    const char* vShaderCode = vertexCode.c_str();
+    const char* fShaderCode = fragmentCode.c_str();
+
+    unsigned int vertex, fragment;
+
+    vertex = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(vertex, 1, &vShaderCode, NULL);
+    glCompileShader(vertex);
+    checkCompileErrors(vertex, "VERTEX");
+
+    fragment = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(fragment, 1, &fShaderCode, NULL);
+    glCompileShader(fragment);
+    checkCompileErrors(fragment, "FRAGMENT");
+
+    unsigned int geometry;
+    if (geometryPath != nullptr) {
+        const char* gShaderCode = geometryCode.c_str();
+        geometry = glCreateShader(GL_GEOMETRY_SHADER);
+        glShaderSource(geometry, 1, &gShaderCode, NULL);
+        glCompileShader(geometry);
+        checkCompileErrors(geometry, "GEOMETRY");
+    }
+
+    ID = glCreateProgram();
+    glAttachShader(ID, vertex);
+    glAttachShader(ID, fragment);
+    if (geometryPath != nullptr) {
+        glAttachShader(ID, geometry);
+    }
+    glLinkProgram(ID);
+    checkCompileErrors(ID, "PROGRAM");
+
+    glDeleteShader(vertex);
+    glDeleteShader(fragment);
+    if (geometryPath != nullptr) {
+        glDeleteShader(geometry);
+    }
+}
+
+Shader::~Shader() {
+    glDeleteProgram(ID);
+}
+
+void Shader::use() {
+    glUseProgram(ID);
+}
+
+void Shader::setBool(const std::string &name, bool value) const {
+    glUniform1i(glGetUniformLocation(ID, name.c_str()), (int)value);
+}
+
+void Shader::setInt(const std::string &name, int value) const {
+    glUniform1i(glGetUniformLocation(ID, name.c_str()), value);
+}
+
+void Shader::setFloat(const std::string &name, float value) const {
+    glUniform1f(glGetUniformLocation(ID, name.c_str()), value);
+}
+
+void Shader::setVec2(const std::string &name, const Eigen::Vector2f &value) const {
+    glUniform2fv(glGetUniformLocation(ID, name.c_str()), 1, value.data());
+}
+
+void Shader::setVec3(const std::string &name, const Eigen::Vector3f &value) const {
+    glUniform3fv(glGetUniformLocation(ID, name.c_str()), 1, value.data());
+}
+
+void Shader::setVec4(const std::string &name, const Eigen::Vector4f &value) const {
+    glUniform4fv(glGetUniformLocation(ID, name.c_str()), 1, value.data());
+}
+
+void Shader::setMat2(const std::string &name, const Eigen::Matrix2f &mat) const {
+    glUniformMatrix2fv(glGetUniformLocation(ID, name.c_str()), 1, GL_FALSE, mat.data());
+}
+
+void Shader::setMat3(const std::string &name, const Eigen::Matrix3f &mat) const {
+    glUniformMatrix3fv(glGetUniformLocation(ID, name.c_str()), 1, GL_FALSE, mat.data());
+}
+
+void Shader::setMat4(const std::string &name, const Eigen::Matrix4f &mat) const {
+    glUniformMatrix4fv(glGetUniformLocation(ID, name.c_str()), 1, GL_FALSE, mat.data());
+}
+
+void Shader::setDMat4(const std::string &name, const Eigen::Matrix4d &mat) const {
+    glUniformMatrix4dv(glGetUniformLocation(ID, name.c_str()), 1, GL_FALSE, mat.data());
+}
+
+void Shader::checkCompileErrors(GLuint shader, std::string type) {
+    GLint success;
+    GLchar infoLog[1024];
+    if (type != "PROGRAM") {
+        glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+        if (!success) {
+            glGetShaderInfoLog(shader, 1024, NULL, infoLog);
+            std::cout << "ERROR::SHADER_COMPILATION_ERROR of type: " << type << "\n" << infoLog << "\n -- --------------------------------------------------- -- " << std::endl;
+        }
+    } else {
+        glGetProgramiv(shader, GL_LINK_STATUS, &success);
+        if (!success) {
+            glGetProgramInfoLog(shader, 1024, NULL, infoLog);
+            std::cout << "ERROR::PROGRAM_LINKING_ERROR of type: " << type << "\n" << infoLog << "\n -- --------------------------------------------------- -- " << std::endl;
+        }
+    }
+}
+
+}


### PR DESCRIPTION
This commit introduces a complete 3D rendering pipeline to the application, allowing for the visualization of loaded STL files.

Key features include:
- A 3D viewport implemented within an ImGui window, using a framebuffer for off-screen rendering.
- A `Camera` class that provides interactive controls (pan, zoom, orbit) for navigating the 3D scene.
- A `Shader` class to encapsulate loading, compiling, and managing GLSL shader programs from files.
- A `RenderableMesh` class to manage the VAO, VBO, and EBO for a given mesh. It correctly handles passing `double` precision vertex data to the GPU by using `GL_DOUBLE` in `glVertexAttribPointer`.
- A shader management system in `GuiClient` that loads multiple shader presets at startup.
- Two shader presets are included:
  1. The existing edge-drawing shader.
  2. A new normal-visualization shader.
- A dropdown menu in the UI allows the user to switch between the installed shader presets at runtime.
- The system is integrated with the existing command processor, automatically creating renderable objects when a new mesh is successfully loaded via the `readStl` command.
- The code has been refactored to use Eigen for all matrix math, removing the need for a GLM dependency.